### PR TITLE
fetch service and dummy test button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import ConfigStorageService from './services/storage/ConfigStorageService';
 import MessageService from './services/MessageService';
 import ConfirmDialog from "./modals/ConfirmDialog";
 import EncounterOptionsModal from "./modals/EncounterOptionsModal";
+import FetchService from './services/FetchService';
 import Link from './monsterbuttons/Link';
 import ListOptionsModal from "./modals/ListOptionsModal";
 import MonsterData from './data/MonsterData';
@@ -123,6 +124,10 @@ class App extends Component {
             BadgeService.updateBadgeCount();
             this.load();
         };
+    }
+
+    handleTestButton = () => {
+        FetchService.postMessageToDiscord('Test button clicked!!!');
     }
 
     //#region children event handlers
@@ -371,6 +376,7 @@ class App extends Component {
                 {this.renderMainContent()}
 
                 {this.renderModalsAndDialogs()}
+                <button onClick={this.handleTestButton}>test button</button>
             </div >
         );
     }

--- a/src/services/FetchService.js
+++ b/src/services/FetchService.js
@@ -1,0 +1,17 @@
+class FetchService {
+  static postMessageToDiscord(message: string) {
+    const discordUrl =
+      'https://discordapp.com/api/webhooks/401954827279794176/3bgGP8IhF77frDRBLr47LK54H7zoYjgPowauLx6ACw0xsDZBCmpFbiYf7S6FbCEE1LoX';
+    const payload = JSON.stringify({ content: message });
+    const params = {
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      method: 'POST',
+      body: payload
+    };
+    fetch(discordUrl, params).error(e=>consle.error(e));
+  }
+}
+
+export default FetchService;

--- a/src/services/FetchService.js
+++ b/src/services/FetchService.js
@@ -10,7 +10,7 @@ class FetchService {
       method: 'POST',
       body: payload
     };
-    fetch(discordUrl, params).error(e=>consle.error(e));
+    fetch(discordUrl, params).error(e=>console.error(e));
   }
 }
 


### PR DESCRIPTION
Changes to App.js should be reverted, but it lets you test. The webhook url is hardcoded here. If this were to become available for general use, you'd need users to add it in the options or something. Otherwise it's super simple.